### PR TITLE
LRU eviction

### DIFF
--- a/TODO
+++ b/TODO
@@ -3,3 +3,4 @@ lru eviction
 follow memcached and/or redis protocol
 client for go and java
 clustering or some sort of distributed caching
+unit tests

--- a/TODO
+++ b/TODO
@@ -4,3 +4,4 @@ follow memcached and/or redis protocol
 client for go and java
 clustering or some sort of distributed caching
 unit tests
+upgrade to golang 1.21 and use slog for logging

--- a/cmd/mimcas/main.go
+++ b/cmd/mimcas/main.go
@@ -18,7 +18,7 @@ import (
 //// lru cache data structure
 
 type Cache struct {
-	items       map[string]*Node // TODO: change to node
+	items       map[string]*Node
 	lruList     *list.List
 	memory 	    int
 	maxmemory   int
@@ -46,7 +46,7 @@ func (c *Cache) insertsHandler() {
 			markAsUsed(node)
 		} else {
 			insertLru(toInsert)
-			c.items[toInsert.key] = toInsert // TODO: BUGGGGGG
+			c.items[toInsert.key] = toInsert
 		}
 	}
 }
@@ -174,7 +174,7 @@ func (c *Cache) mget(params []string) string {
 				} else {
 					response = response + value + "\n"
 				}
-			} else { // TODO something wrong here (?)
+			} else {
 				response = response + "(nil)\n"
 			}
 		}


### PR DESCRIPTION
## Description of the Change
- Get LRU eviction to work
- Added `memoryHandler` goroutine for measuring memory and request evictions. This handler receives memory deltas continuously though a channel.

## Benefits
This is core functionality for the cached towards the v0.1.0.

## Drawbacks
It increases complexity, specially in the set command.